### PR TITLE
Fixed issue with IPv4/IPv6 support and ansible-role-bounca

### DIFF
--- a/templates/site.j2
+++ b/templates/site.j2
@@ -8,7 +8,7 @@ server {
 
 {% if item.ssl is defined and item.ssl.key != None %}
 listen {{ item.listen }} ssl;
-{% if not item.ipv4_only %}
+{% if not (item.ipv4_only is defined and item.ipv4_only == True) %}
 listen [::]:{{ item.listen }} ssl;
 {% endif %}
 ssl_certificate {{ nginx_ssl_dir }}/{{ item.ssl.certificate }};
@@ -19,14 +19,14 @@ add_header Strict-Transport-Security max-age=31536000;
 add_header X-Frame-Options DENY;
 {% else %}
 listen {{ item.listen }};
-{% if not item.ipv4_only %}
+{% if not (item.ipv4_only is defined and item.ipv4_only == True) %}
 listen [::]:{{ item.listen }};
 {% endif %}
 {% endif %}
 
 
 {% for k,v in item.iteritems() %}
-{% if k.find('locations') == -1 and k != 'file_name' and k != 'listen' and k != 'ssl' %}
+{% if k.find('locations') == -1 and k != 'file_name' and k != 'listen' and k != 'ssl' and k != 'ipv4_only' %}
 {{ k }} {{ v }};
 {% endif %}
 {% endfor %} 

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -8,7 +8,7 @@ server {
 
 {% if item.ssl is defined and item.ssl.key != None %}
 listen {{ item.listen }} ssl;
-{% if not (item.ipv4_only is defined and item.ipv4_only == True) %}
+{% if not (item.ipv4_only is defined and item.ipv4_only == False) %}
 listen [::]:{{ item.listen }} ssl;
 {% endif %}
 ssl_certificate {{ nginx_ssl_dir }}/{{ item.ssl.certificate }};
@@ -19,7 +19,7 @@ add_header Strict-Transport-Security max-age=31536000;
 add_header X-Frame-Options DENY;
 {% else %}
 listen {{ item.listen }};
-{% if not (item.ipv4_only is defined and item.ipv4_only == True) %}
+{% if not (item.ipv4_only is defined and item.ipv4_only == False) %}
 listen [::]:{{ item.listen }};
 {% endif %}
 {% endif %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,7 +6,41 @@
           nginx_create_nginx_conf: true,
           nginx_http_params: { 
           },
-          nginx_sites: []
+          nginx_sites: [{
+                  file_name: test,
+                  listen: 80,
+                  server_name: localhost,                  
+                  locations: [{
+                      name: /static,
+                      lines: [
+                        "root /srv/www/static",
+                        "include mime.types"
+                      ]
+                    },
+                   {
+                      name: /,
+                      lines: [
+                        "root /srv/www/dynamic"
+                      ]
+                    },
+                    {
+                      name: /wrong/url,
+                      lines: [
+                        "return 404"
+                      ]
+                    }]
+                  }, {
+                  file_name: test2,
+                  listen: 81,
+                  server_name: localhost,
+                  ipv4_only: true,                  
+                  locations: [{
+                      name: /,
+                      lines: [
+                        "return 404"
+                      ]
+                    }]
+                }]
       }
 
       


### PR DESCRIPTION
Latest version breaks ansible-role-bounca because of missing ipv4_only dict property. This should fix this and is backwards compatible.